### PR TITLE
Separate bundle and output to improve memory usage over memoization

### DIFF
--- a/src/utils/buildRollupConfig.ts
+++ b/src/utils/buildRollupConfig.ts
@@ -2,7 +2,17 @@ import { FunctionEntry } from "./getEntryForFunction";
 import { RollupOptions, RollupCache } from "rollup";
 import path from "path";
 
-export default (
+export const buildInputConfig = (
+  input: string,
+  rollupConfig: RollupOptions,
+  cache: RollupCache
+): RollupOptions => ({
+    ...rollupConfig,
+    input,
+    cache
+  });
+
+export const buildOutputConfig = (
   functionEntry: FunctionEntry,
   rollupConfig: RollupOptions,
   cache: RollupCache
@@ -18,7 +28,6 @@ export default (
   return {
     output: configOutput,
     ...rollupConfig,
-    input: functionEntry.source,
     cache
   };
 };

--- a/src/utils/rollupFunctionEntry.ts
+++ b/src/utils/rollupFunctionEntry.ts
@@ -1,4 +1,4 @@
-import buildRollupConfig from "./buildRollupConfig";
+import { buildInputConfig, buildOutputConfig } from "./buildRollupConfig";
 import { FunctionEntry } from "./getEntryForFunction";
 import rollup, {
   RollupOptions,
@@ -6,29 +6,35 @@ import rollup, {
   OutputOptions,
   RollupOutput,
   RollupCache,
-  InputOption,
 } from "rollup";
 
-const bundlesMemo = new Map<InputOption, RollupBuild>();
 let cache: RollupCache;
-export default async (
-  functionEntry: FunctionEntry,
-  rollupConfig: RollupOptions
+export const buildBundle = async (
+  input: string,
+  rollupConfig: RollupOptions,
 ) => {
-  const config: RollupOptions = buildRollupConfig(
-    functionEntry,
+  const config: RollupOptions = buildInputConfig(
+    input,
     rollupConfig,
     cache
   );
 
-  const bundle =
-    bundlesMemo.get(config.input) ||
-    (await (async () => {
-      const bundle: RollupBuild = await rollup.rollup(config);
-      cache = bundle.cache;
-      bundlesMemo.set(config.input, bundle);
-      return bundle;
-    })());
+  const bundle: RollupBuild = await rollup.rollup(config);
+  cache = bundle.cache;
+
+  return bundle;
+};
+
+export const outputBundle = async (
+  bundle: RollupBuild,
+  functionEntry: FunctionEntry,
+  rollupConfig: RollupOptions,
+) => {
+  const config: RollupOptions = buildOutputConfig(
+    functionEntry,
+    rollupConfig,
+    cache
+  );
 
   const rollupOutput: RollupOutput = await bundle.write(
     config.output as OutputOptions


### PR DESCRIPTION
This is to fix an issue introduced with my last feature #26 (oops again, sorry ><;;)
While this change got my build times down from 6min 14sec to 3min 41sec, it caused my build server to crash, probably due to memory issues.
Here I opted to separate the bundle and build processes into two separate functions. This allows me to remove the memoization `Map` and keep only bundling a single input file once, then outputting it many times for different functions.